### PR TITLE
Pickle Fix

### DIFF
--- a/engines/badger/badger.go
+++ b/engines/badger/badger.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/rotationalio/honu/config"
+	engine "github.com/rotationalio/honu/engines"
 )
 
 func Open(conf config.ReplicaConfig) (*BadgerEngine, error) {
@@ -18,4 +19,8 @@ func (db *BadgerEngine) Engine() string {
 
 func (db *BadgerEngine) Close() error {
 	return errors.New("not implemented yet")
+}
+
+func (db *BadgerEngine) Begin(readonly bool) (engine.Transaction, error) {
+	return nil, errors.New("not implemented yet")
 }

--- a/engines/engine.go
+++ b/engines/engine.go
@@ -14,17 +14,26 @@ type Engine interface {
 
 	// Close the engine so that it no longer can be accessed.
 	Close() error
+
+	// Begin a transaction to issue multiple commands (this is an internal transaction
+	// for Honu-specific version management, not an external interface).
+	Begin(readonly bool) (tx Transaction, err error)
 }
 
 // Store is a simple key/value interface that allows for Get, Put, and Delete. Nearly
 // all engines should support the Store interface.
 type Store interface {
-	Get(key []byte, options ...opts.SetOptions) (value []byte, err error)
-	Put(key, value []byte, options ...opts.SetOptions) error
-	Delete(key []byte, options ...opts.SetOptions) error
+	Get(key []byte, options *opts.Options) (value []byte, err error)
+	Put(key, value []byte, options *opts.Options) error
+	Delete(key []byte, options *opts.Options) error
 }
 
 // Iterator engines allow queries that scan a range of consecutive keys.
 type Iterator interface {
-	Iter(prefix []byte) (i iterator.Iterator, err error)
+	Iter(prefix []byte, options *opts.Options) (i iterator.Iterator, err error)
+}
+
+type Transaction interface {
+	Store
+	Finish() error
 }

--- a/engines/errors.go
+++ b/engines/errors.go
@@ -3,5 +3,6 @@ package engine
 import "errors"
 
 var (
-	ErrNotFound = errors.New("not found")
+	ErrNotFound   = errors.New("not found")
+	ErrReadOnlyTx = errors.New("cannot execute a write operation in a read only transaction")
 )

--- a/engines/leveldb/iter.go
+++ b/engines/leveldb/iter.go
@@ -1,6 +1,8 @@
 package leveldb
 
 import (
+	"bytes"
+
 	honuiter "github.com/rotationalio/honu/iterator"
 	pb "github.com/rotationalio/honu/object"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
@@ -23,9 +25,18 @@ var _ honuiter.Iterator = &ldbIterator{}
 
 func (i *ldbIterator) Next() bool   { return i.ldb.Next() }
 func (i *ldbIterator) Prev() bool   { return i.ldb.Prev() }
-func (i *ldbIterator) Key() []byte  { return i.ldb.Key() }
 func (i *ldbIterator) Error() error { return i.ldb.Error() }
 func (i *ldbIterator) Release()     { i.ldb.Release() }
+
+func (i *ldbIterator) Key() []byte {
+	// Fetch the key then split the namespace from the key
+	key := i.ldb.Key()
+	parts := bytes.SplitN(key, nssep, 2)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return key
+}
 
 func (i *ldbIterator) Value() []byte {
 	obj, _ := i.Object()

--- a/engines/pebble/pebble.go
+++ b/engines/pebble/pebble.go
@@ -33,6 +33,10 @@ func (db *PebbleEngine) Close() error {
 	return db.pebble.Close()
 }
 
+func (db *PebbleEngine) Begin(readonly bool) (engine.Transaction, error) {
+	return nil, errors.New("not implemented yet")
+}
+
 // Get the latest version of the object stored by the key.
 func (db *PebbleEngine) Get(key []byte, options ...opts.SetOptions) (value []byte, err error) {
 	value, closer, err := db.pebble.Get(key)

--- a/options/options.go
+++ b/options/options.go
@@ -5,42 +5,78 @@ import (
 	ldb "github.com/syndtr/goleveldb/leveldb/opt"
 )
 
-//Contains all available read/write options
-//for the supported databases. Fields are set
-//by functions using the SetOptions signature.
-type Options struct {
-	LeveldbRead  *ldb.ReadOptions
-	LeveldbWrite *ldb.WriteOptions
-	PebbleWrite  *pebble.WriteOptions
+const (
+	defaultNamespace = "default"
+)
+
+// New creates a per-call Options object based on the variadic SetOptions closures
+// supplied by the user. New also sets sensible defaults for various options.
+func New(options ...SetOptions) (cfg *Options, err error) {
+	cfg = &Options{Namespace: defaultNamespace}
+	for _, option := range options {
+		if err = option(cfg); err != nil {
+			return nil, err
+		}
+	}
+	return cfg, nil
 }
 
-//Defining the signature of functions accepted
-//as parameters by engine.Store functions.
+// Contains all available read/write options for the supported engines. Fields are set
+// by closures implementing the SetOptions signature.
+type Options struct {
+	LevelDBRead  *ldb.ReadOptions
+	LevelDBWrite *ldb.WriteOptions
+	PebbleWrite  *pebble.WriteOptions
+	Namespace    string
+	Destroy      bool
+}
+
+// Defines the signature of functions accepted as parameters by Honu methods.
 type SetOptions func(cfg *Options) error
+
+// WithNamespace returns a closure that sets a namespace other than the default.
+func WithNamespace(namespace string) SetOptions {
+	return func(cfg *Options) error {
+		cfg.Namespace = namespace
+		return nil
+	}
+}
+
+// WithDestroy returns a closure that sets an option so that instead of creating a
+// tombstone, the data is permanently deleted from the database, meaning that a
+// subsequent Put will restart the versioning. Use Destroy with care in a distributed
+// system, if you destroy a key in an anti-entropy environment it will simply be
+// repaired by the system to the latest version before the Delete.
+func WithDestroy() SetOptions {
+	return func(cfg *Options) error {
+		cfg.Destroy = true
+		return nil
+	}
+}
 
 //Closure returning a function that adds the leveldbRead
 //parameter to an Options struct's LeveldbRead field.
-func WithLeveldbRead(leveldbRead *ldb.ReadOptions) SetOptions {
+func WithLeveldbRead(opts *ldb.ReadOptions) SetOptions {
 	return func(cfg *Options) error {
-		cfg.LeveldbRead = leveldbRead
+		cfg.LevelDBRead = opts
 		return nil
 	}
 }
 
 //Closure returning a function that adds the leveldbWrite
 //parameter to an Options struct's LeveldbWrite field.
-func WithLeveldbWrite(leveldbWrite *ldb.WriteOptions) SetOptions {
+func WithLeveldbWrite(opts *ldb.WriteOptions) SetOptions {
 	return func(cfg *Options) error {
-		cfg.LeveldbWrite = leveldbWrite
+		cfg.LevelDBWrite = opts
 		return nil
 	}
 }
 
 //Closure returning a function that adds the pebbleWrite
 //parameter to an Options struct's PebbleWrite field.
-func WithPebbleWrite(pebbleWrite *pebble.WriteOptions) SetOptions {
+func WithPebbleWrite(opts *pebble.WriteOptions) SetOptions {
 	return func(cfg *Options) error {
-		cfg.PebbleWrite = pebbleWrite
+		cfg.PebbleWrite = opts
 		return nil
 	}
 }

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -9,6 +9,20 @@ import (
 	ldb "github.com/syndtr/goleveldb/leveldb/opt"
 )
 
+func TestHonuOptions(t *testing.T) {
+	// Test default options
+	opts, err := options.New()
+	require.NoError(t, err, "could not create options")
+	require.Equal(t, "default", opts.Namespace)
+	require.False(t, opts.Destroy)
+
+	// Test setting multiple options
+	opts, err = options.New(options.WithDestroy(), options.WithNamespace("foo"))
+	require.NoError(t, err, "could not create options")
+	require.Equal(t, "foo", opts.Namespace)
+	require.True(t, opts.Destroy)
+}
+
 func TestLevelDBReadOptions(t *testing.T) {
 	readOptions := &ldb.ReadOptions{
 		DontFillCache: true,
@@ -17,7 +31,7 @@ func TestLevelDBReadOptions(t *testing.T) {
 	cfg := &options.Options{}
 	ldbReadFunc := options.WithLeveldbRead(readOptions)
 	ldbReadFunc(cfg)
-	require.Equal(t, cfg.LeveldbRead, readOptions)
+	require.Equal(t, cfg.LevelDBRead, readOptions)
 }
 
 func TestLevelDBWriteOptions(t *testing.T) {
@@ -28,7 +42,7 @@ func TestLevelDBWriteOptions(t *testing.T) {
 	cfg := &options.Options{}
 	ldbWriteFunc := options.WithLeveldbWrite(writeOptions)
 	ldbWriteFunc(cfg)
-	require.Equal(t, cfg.LeveldbWrite, writeOptions)
+	require.Equal(t, cfg.LevelDBWrite, writeOptions)
 
 }
 


### PR DESCRIPTION
This commit fixes a pickle we were in with a production implementation that uses Honu (even though Honu is still in a prototype phase). The following changes were made:

1. Implementing a basic Transaction interface to ensure that multiple access operations in `Put` and `Delete` are consistent.
2. Implementing a `WithNamespace()` option to use more than the default namespace.
3. Returning object metadata from `Put` and `Delete`
4. Updating the leveldb implementation to use a global lock for read/write transactions
5. Updating the leveldb implementation to use `namespace::key` prefixes for namespace storage. 