### PR TITLE
Update Version Checks

### DIFF
--- a/honu_test.go
+++ b/honu_test.go
@@ -126,10 +126,28 @@ func TestLevelDBInteractions(t *testing.T) {
 		require.Equal(t, "here", obj.Version.Region)
 
 		// Update with same namespace option should not error.
+		obj.Version.Version = 43
 		require.NoError(t, db.Update(obj, options.WithNamespace(namespace)))
 
 		// Update with wrong namespace should error
 		require.Error(t, db.Update(obj, options.WithNamespace("this is not the right thing")))
+
+		// Update with wrong namespace but with force should not error.
+		require.NoError(t, db.Update(obj, options.WithNamespace("trashcan"), options.WithForce()))
+
+		// Update with the same version should error.
+		require.Error(t, db.Update(obj, options.WithNamespace(namespace)))
+
+		// Update with an earlier version should error
+		obj.Version.Version = 7
+		require.Error(t, db.Update(obj, options.WithNamespace(namespace)))
+
+		// Update with an earlier version with force should not error.
+		require.NoError(t, db.Update(obj, options.WithNamespace(namespace), options.WithForce()))
+
+		// Update an object that does not exist should not error.
+		obj.Key = []byte("secretobjinvisible")
+		require.NoError(t, db.Update(obj, options.WithNamespace(namespace)))
 
 		// TODO: figure out what to do with this testcase.
 		// Iter currently grabs the namespace by splitting

--- a/options/options.go
+++ b/options/options.go
@@ -28,6 +28,7 @@ type Options struct {
 	LevelDBWrite *ldb.WriteOptions
 	PebbleWrite  *pebble.WriteOptions
 	Namespace    string
+	Force        bool
 }
 
 // Defines the signature of functions accepted as parameters by Honu methods.
@@ -40,6 +41,14 @@ func WithNamespace(namespace string) Option {
 		if namespace != "" {
 			cfg.Namespace = namespace
 		}
+		return nil
+	}
+}
+
+// WithForce prevents validation checks from returning an error during accesses.
+func WithForce() Option {
+	return func(cfg *Options) error {
+		cfg.Force = true
 		return nil
 	}
 }


### PR DESCRIPTION
This PR implements a required change for Trtl Anti-Entropy: Update checks if the version being updated is still later than the local version. I've also added a `WithForce()` option that bypasses checks if the user wants to force put an object to the database, overriding the namespace and version checks.

This is related to https://github.com/trisacrypto/directory/pull/299

Note this is related to sc-2703 but is not a complete implementation; this PR only does enough to fix sc-2694. 