### PR TITLE
Skip, stomp, and linear version history tracking in Update

### DIFF
--- a/object/object.go
+++ b/object/object.go
@@ -17,7 +17,18 @@ func (v *Version) IsZero() bool {
 }
 
 // IsLater returns true if the specified version is later than the other version. It
-// returns false if the other version is later or equal to the specified version.
+// returns false if the other version is later or equal to the specified version. If
+// other is nil, it is considered equivalent to the zero-valued version.
+//
+// Versions are Lamport Scalars composed of a monotonically increasing scalar component
+// along with a tiebreaking component called the PID (the process ID of a replica). If
+// the scalar is greater than the other scaler, then the Version is later. If the
+// scalars are equal, then the version with the lower PID has higher precedence.
+// Versions are conflict free so long as the processes that increment the scalar have a
+// unique PID. E.g. if two processes concurrently increment the scalar to the same value
+// then unique PIDs guarantee that one of those processes will have precedence. Lower
+// PIDs are used for the higher precedence because of the PIDs are assigned in
+// increasing order, then the lower PIDs are older replicas.
 func (v *Version) IsLater(other *Version) bool {
 	// If other is nil, then we assume it represents the zero-valued version.
 	if other == nil {
@@ -35,8 +46,60 @@ func (v *Version) IsLater(other *Version) bool {
 		return true
 	}
 
-	// Either v.Version < other.Version or other.Pid > v.Pid
+	// Either v.Version < other.Version, other.Pid > v.Pid, or the versions are equal.
 	return false
+}
+
+// Equal returns true if and only if the Version scalars and PIDs are equal. Nil is
+// considered to be the zero valued Version.
+func (v *Version) Equal(other *Version) bool {
+	// If other is nil, then we assume it represents the zero-valued version.
+	if other == nil {
+		other = &VersionZero
+	}
+	return v.Version == other.Version && v.Pid == other.Pid
+}
+
+// Concurrent returns true if and only if the Version scalars are equal but the PIDs are
+// not equal. Nil is considered to be the zero valued Version.
+func (v *Version) Concurrent(other *Version) bool {
+	// If other is nil, then we assume it represents the zero-valued version.
+	if other == nil {
+		other = &VersionZero
+	}
+	return v.Version == other.Version && v.Pid != other.Pid
+}
+
+// LinearFrom returns true if and only if the the parent of this version is equal to the
+// other version. E.g. is this version created from the other version (a child of).
+// LinearFrom implies that this version is later than the other version so long as the
+// child is always later than the parent version.
+//
+// NOTE: this method cannot detect a linear chain through multiple ancestors to the
+// current version - it is a direct relationship only. A complete version history is
+// required to compute a longer linear chain and branch points.
+func (v *Version) LinearFrom(other *Version) bool {
+	// Handle the case of the root version (no parent)
+	if v.Parent == nil {
+		return other == nil || other.IsZero()
+	}
+	return v.Parent.Equal(other)
+}
+
+// Stomps returns true if and only if this version is both concurrent and later than the
+// other version; e.g. this version is concurrent and would have precedence.
+func (v *Version) Stomps(other *Version) bool {
+	return v.Concurrent(other) && v.IsLater(other)
+}
+
+// Skips returns true if and only if this version is later, is not concurrent (e.g. is
+// not a stomp) and is not linear from the other version, e.g. this version is at least
+// one version farther in the version history than the other version. Skips does not
+// imply a stomp, though a stomp is possible in the version chain between the skip.
+// Skips really mean that the  replica does not have enough information to determine if
+// a stomp has occurred or if we've just moved forward in a linear chain.
+func (v *Version) Skips(other *Version) bool {
+	return v.IsLater(other) && !v.Concurrent(other) && !v.LinearFrom(other)
 }
 
 //Copies the child's attributes before updating to the parent.

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -25,14 +25,166 @@ func TestTombstone(t *testing.T) {
 }
 
 func TestVersionIsLater(t *testing.T) {
+	// Create a version with non-zero values to test against
 	v1 := &Version{Pid: 8, Version: 42}
-	require.True(t, v1.IsLater(nil))
-	require.True(t, v1.IsLater(&VersionZero))
-	require.False(t, VersionZero.IsLater(v1))
-	require.False(t, VersionZero.IsLater(nil))
-	require.False(t, VersionZero.IsLater(&VersionZero))
-	require.True(t, v1.IsLater(&Version{Pid: 8, Version: 40}))
-	require.True(t, v1.IsLater(&Version{Pid: 9, Version: 42}))
-	require.False(t, v1.IsLater(&Version{Pid: 7, Version: 42}))
-	require.False(t, v1.IsLater(&Version{Pid: 8, Version: 44}))
+
+	// Tests against version zero
+	require.True(t, v1.IsLater(&VersionZero), "version should be later than zero value")
+	require.True(t, v1.IsLater(nil), "version should treat nil as zero value")
+	require.False(t, VersionZero.IsLater(v1), "zero value should not be later than version")
+
+	require.False(t, VersionZero.IsLater(&VersionZero), "zero value should not be later than itself")
+	require.False(t, VersionZero.IsLater(nil), "zero value should not be later than nil")
+
+	// Test against other versions
+	require.True(t, v1.IsLater(&Version{Pid: 8, Version: 40}), "version should be later than version with lesser scalar but same pid")
+	require.True(t, v1.IsLater(&Version{Pid: 9, Version: 42}), "concurrent version should be later than lower precedence pid")
+	require.False(t, v1.IsLater(&Version{Pid: 7, Version: 42}), "concurrent version should not be later than higher precedence pid")
+	require.False(t, v1.IsLater(&Version{Pid: 8, Version: 44}), "version should not be later than version with greater scaler but same pid")
+	require.False(t, v1.IsLater(&Version{Pid: 8, Version: 42}), "version should not be later than an equal version")
+}
+
+func TestVersionEqual(t *testing.T) {
+	// Test if a version is equal to an identical version
+	v1 := &Version{Pid: 8, Version: 42}
+	v2 := &Version{Pid: 8, Version: 42}
+	require.True(t, v1.Equal(v2), "two versions with same PID and scalar should be equal")
+	require.True(t, v2.Equal(v1), "version equality should be reciprocal")
+	require.True(t, v1.Equal(v1), "a version object should be equal to itself")
+
+	// Test no equality
+	require.False(t, v1.Equal(&VersionZero), "a version should not be equal to zero value")
+	require.False(t, v1.Equal(nil), "a version should not be equal to nil")
+	require.False(t, VersionZero.Equal(v2), "zero value should not be equal to a version")
+	require.False(t, v1.Equal(&Version{Pid: 9, Version: 42}), "versions with different PIDs should not be equal")
+	require.False(t, v1.Equal(&Version{Pid: 9, Version: 41}), "versions with different PIDs and scalars should not be equal")
+	require.False(t, v1.Equal(&Version{Pid: 8, Version: 43}), "versions with a greater scalar should not be equal")
+	require.False(t, v1.Equal(&Version{Pid: 8, Version: 41}), "versions with a lesser scalar should not be equal")
+
+	// Test zero-versioned equality
+	require.True(t, VersionZero.Equal(nil), "zero value should equal nil")
+	require.True(t, VersionZero.Equal(&VersionZero), "zero value should equal zero value")
+}
+
+func TestVersionConcurrent(t *testing.T) {
+	// Test two concurrent versions
+	v1 := &Version{Pid: 8, Version: 42}
+	v2 := &Version{Pid: 12, Version: 42}
+
+	require.True(t, v1.Concurrent(v2), "versions should be concurrent with same scalar and different PID")
+	require.True(t, v2.Concurrent(v1), "concurrent should be reciprocal")
+
+	// Equal, later, and earlier versions should not be concurrent even if they have the same PID
+	require.False(t, v1.Concurrent(&Version{Pid: 8, Version: 42}), "equal versions should not be concurrent")
+	require.False(t, v1.Concurrent(&Version{Pid: 12, Version: 48}), "later versions should not be concurrent")
+	require.False(t, v1.Concurrent(&Version{Pid: 12, Version: 21}), "earlier versions should not be concurrent")
+	require.False(t, v1.Concurrent(&VersionZero), "zero version should not be concurrent")
+	require.False(t, v1.Concurrent(nil), "nil should be treated as zero version")
+
+	// Test zero-versioned concurrency
+	require.False(t, VersionZero.Concurrent(&VersionZero), "zero version should not be concurrent with itself")
+	require.False(t, VersionZero.Concurrent(nil), "zero version should not be concurrent with nil")
+	require.False(t, VersionZero.Concurrent(v1), "zero version should not be concurrent with another version")
+}
+
+func TestLinearFrom(t *testing.T) {
+	// Root version
+	v1 := &Version{Pid: 8, Version: 1, Parent: nil}
+
+	// Linear from v1 but with different PIDs
+	v2 := &Version{Pid: 8, Version: 2, Parent: &Version{Pid: 8, Version: 1}}
+	v3 := &Version{Pid: 9, Version: 2, Parent: &Version{Pid: 8, Version: 1}}
+
+	// Linear from v3
+	v4 := &Version{Pid: 9, Version: 3, Parent: &Version{Pid: 9, Version: 2}}
+
+	require.True(t, v1.LinearFrom(&VersionZero), "root version should be linear from version zero")
+	require.True(t, v1.LinearFrom(nil), "should treat nil as the zero version")
+	require.False(t, v1.LinearFrom(v2), "parent should not be linear from child")
+
+	require.True(t, v2.LinearFrom(v1), "version should be linear from its parent, same PID")
+	require.True(t, v3.LinearFrom(v1), "version should be linear from its parent, different PID")
+	require.True(t, v4.LinearFrom(v3), "a child should be linear from its parent")
+
+	require.False(t, v2.LinearFrom(v3), "concurrent should not be linear from, other version")
+	require.False(t, v3.LinearFrom(v2), "stomp should not be linear from other version")
+
+	require.False(t, v4.LinearFrom(v2), "a child should not be linear from stomped version")
+	require.False(t, v4.LinearFrom(v1), "a skip should not be linear from earlier version")
+	require.False(t, v1.LinearFrom(v4), "version should not be linear from later version")
+}
+
+func TestStomps(t *testing.T) {
+	// Root version
+	v1 := &Version{Pid: 8, Version: 1, Parent: nil}
+
+	require.False(t, v1.Stomps(&VersionZero), "root version should not stomp version zero")
+	require.False(t, v1.Stomps(nil), "should treat nil as the zero version")
+	require.False(t, v1.Stomps(&Version{Pid: 8, Version: 1}), "version should not stomp equal version")
+
+	// Linear from v1 but with different PIDs (v2 stomps v3)
+	v2 := &Version{Pid: 8, Version: 2, Parent: &Version{Pid: 8, Version: 1}}
+	v3 := &Version{Pid: 9, Version: 2, Parent: &Version{Pid: 8, Version: 1}}
+
+	require.True(t, v2.Stomps(v3), "stomps should be detected for concurrent versions")
+	require.False(t, v3.Stomps(v2), "only one concurrent version should stomp the other")
+	require.False(t, v2.Stomps(v2), "version should not stomp itself")
+
+	// Linear from v3 (should not stomp v2 even though it's later)
+	v4 := &Version{Pid: 9, Version: 3, Parent: &Version{Pid: 9, Version: 2}}
+	require.False(t, v4.Stomps(v2), "later version should not stomp earlier version if not concurent")
+	require.False(t, v4.Stomps(v3), "version should not stomp its parent")
+}
+
+func TestSkips(t *testing.T) {
+	// Root version
+	v1 := &Version{Pid: 8, Version: 1, Parent: nil}
+
+	require.False(t, v1.Skips(&VersionZero), "root version should not skip zero value")
+	require.False(t, v1.Skips(nil), "should treat nil as the zero version")
+	require.False(t, v1.Skips(&Version{Pid: 8, Version: 1}), "version should not skip equal version")
+
+	// Linear from v1 but with different PIDs (v2 stomps v3)
+	v2 := &Version{Pid: 8, Version: 2, Parent: &Version{Pid: 8, Version: 1}}
+	v3 := &Version{Pid: 9, Version: 2, Parent: &Version{Pid: 8, Version: 1}}
+
+	require.False(t, v2.Skips(v1), "version should not skip its parent")
+	require.False(t, v2.Skips(v3), "stomp should not be a skip")
+	require.False(t, v3.Skips(v2), "concurrent version should not be a skip")
+
+	// Linear from v3 (skips v3 from v1)
+	v4 := &Version{Pid: 9, Version: 3, Parent: &Version{Pid: 9, Version: 2}}
+	require.True(t, v4.Skips(v1), "a later version should skip an earlier version if parent is not equal")
+	require.True(t, v4.Skips(v2), "a branch should be considered a skip if the parent was stomped")
+	require.False(t, v4.Skips(v3), "a child should not skip a non-root parent")
+}
+
+func TestVersionHistory(t *testing.T) {
+	// Create a version history without reusing pointers
+	v71 := &Version{Pid: 7, Version: 1, Parent: nil}
+	v72 := &Version{Pid: 7, Version: 2, Parent: &Version{Pid: 7, Version: 1}}
+	v73 := &Version{Pid: 7, Version: 3, Parent: &Version{Pid: 7, Version: 2}}
+	v83 := &Version{Pid: 8, Version: 3, Parent: &Version{Pid: 7, Version: 2}}
+	v74 := &Version{Pid: 7, Version: 4, Parent: &Version{Pid: 7, Version: 3}}
+	v84 := &Version{Pid: 8, Version: 4, Parent: &Version{Pid: 8, Version: 3}}
+	v85 := &Version{Pid: 8, Version: 5, Parent: &Version{Pid: 8, Version: 4}}
+	v95 := &Version{Pid: 9, Version: 5, Parent: &Version{Pid: 7, Version: 4}}
+	v76 := &Version{Pid: 7, Version: 6, Parent: &Version{Pid: 9, Version: 5}}
+	v97 := &Version{Pid: 9, Version: 7, Parent: &Version{Pid: 7, Version: 6}}
+
+	// Test the 71 through 97 linear history
+	history := []*Version{v71, v72, v73, v74, v95, v76, v97}
+	for i := 1; i < len(history); i++ {
+		parent := history[i-1]
+		current := history[i]
+		require.True(t, current.LinearFrom(parent), "%s should be linear from %s", current, parent)
+	}
+
+	// Test the 71 through 85 linear history
+	history = []*Version{v71, v72, v83, v84, v85}
+	for i := 1; i < len(history); i++ {
+		parent := history[i-1]
+		current := history[i]
+		require.True(t, current.LinearFrom(parent), "%s should be linear from %s", current, parent)
+	}
 }


### PR DESCRIPTION
Adds an UpdateType return value to the db.Update method so callers can track what happens to the underlying version history. The types are directly connected to new Version comparison methods of similar names, which will hopefully make it easier for us to reason about whats happening in the version history and in anti-entropy in general.

For `TestStomps`, `TestLinearFrom`, and `TestSkips` - the following figure may be helpful in describing what the expected versions are:

![Paper Journal 14 2](https://user-images.githubusercontent.com/745966/151078389-a4771491-6f36-4607-9345-1176ae7bf8ac.png)

