### PR TITLE
Expose levelDB object

### DIFF
--- a/engines/leveldb/leveldb.go
+++ b/engines/leveldb/leveldb.go
@@ -34,6 +34,12 @@ type Transaction struct {
 	ro bool
 }
 
+// Returns the underlying database object for direct access by the caller, to enable
+// backups, etc.
+func (db *LevelDBEngine) DB() *leveldb.DB {
+	return db.ldb
+}
+
 // Returns the name of the engine type.
 func (db *LevelDBEngine) Engine() string {
 	return "leveldb"

--- a/honu.go
+++ b/honu.go
@@ -349,3 +349,8 @@ func (db *DB) Iter(prefix []byte, options ...opts.Option) (i iterator.Iterator, 
 	}
 	return iter.Iter(prefix, cfg)
 }
+
+// Returns the underlying DB engine for direct access.
+func (db *DB) Engine() engine.Engine {
+	return db.engine
+}


### PR DESCRIPTION
This exposes the underlying levelDB object to the user to make it easier to do things like backups.