### PR TITLE
Better Tombstone handling in Iter

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,7 +1,6 @@
 package honu_test
 
 import (
-	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -22,26 +21,26 @@ var (
 
 func setupLevelDB(t testing.TB) (*leveldb.DB, string) {
 	// Create a new leveldb database in a temporary directory
-	tmpDir, err := ioutil.TempDir("", "honuldb-*")
+	tmpDir, err := ioutil.TempDir("", "leveldb-*")
 	require.NoError(t, err)
 
 	// Open a leveldb database directly without honu wrapper
 	db, err := leveldb.OpenFile(tmpDir, nil)
-	require.NoError(t, err)
 	if err != nil && tmpDir != "" {
-		fmt.Println(tmpDir)
 		os.RemoveAll(tmpDir)
 	}
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+		os.RemoveAll(tmpDir)
+	})
+
 	return db, tmpDir
 }
 
 func BenchmarkHonuGet(b *testing.B) {
-	db, tmpDir := setupHonuDB(b)
-
-	// Cleanup when we're done with the test
-	// NOTE: defers are evaluated in FIFO order, so this ensures the db is closed first then the directory deleted
-	defer os.RemoveAll(tmpDir)
-	defer db.Close()
+	db, _ := setupHonuDB(b)
 
 	// Create a key and value
 	key := []byte("foo")
@@ -63,11 +62,7 @@ func BenchmarkHonuGet(b *testing.B) {
 }
 
 func BenchmarkLevelDBGet(b *testing.B) {
-	db, tmpDir := setupLevelDB(b)
-
-	// Cleanup when we're done with the test
-	defer os.RemoveAll(tmpDir)
-	defer db.Close()
+	db, _ := setupLevelDB(b)
 
 	// Create a key and value
 	key := []byte("foo")
@@ -88,11 +83,7 @@ func BenchmarkLevelDBGet(b *testing.B) {
 }
 
 func BenchmarkHonuPut(b *testing.B) {
-	db, tmpDir := setupHonuDB(b)
-
-	// Cleanup when we're done with the test
-	defer os.RemoveAll(tmpDir)
-	defer db.Close()
+	db, _ := setupHonuDB(b)
 
 	// Create a key and value
 	key := []byte("foo")
@@ -110,11 +101,7 @@ func BenchmarkHonuPut(b *testing.B) {
 }
 
 func BenchmarkLevelDBPut(b *testing.B) {
-	db, tmpDir := setupLevelDB(b)
-
-	// Cleanup when we're done with the test
-	defer os.RemoveAll(tmpDir)
-	defer db.Close()
+	db, _ := setupLevelDB(b)
 
 	// Create a key and value
 	key := []byte("foo")
@@ -132,11 +119,7 @@ func BenchmarkLevelDBPut(b *testing.B) {
 }
 
 func BenchmarkHonuDelete(b *testing.B) {
-	db, tmpDir := setupHonuDB(b)
-
-	// Cleanup when we're done with the test
-	defer os.RemoveAll(tmpDir)
-	defer db.Close()
+	db, _ := setupHonuDB(b)
 
 	// Create a key and value
 	key := []byte("foo")
@@ -158,11 +141,7 @@ func BenchmarkHonuDelete(b *testing.B) {
 }
 
 func BenchmarkLevelDBDelete(b *testing.B) {
-	db, tmpDir := setupLevelDB(b)
-
-	// Cleanup when we're done with the test
-	defer os.RemoveAll(tmpDir)
-	defer db.Close()
+	db, _ := setupLevelDB(b)
 
 	// Create a key and value
 	key := []byte("foo")
@@ -183,11 +162,7 @@ func BenchmarkLevelDBDelete(b *testing.B) {
 }
 
 func BenchmarkHonuIter(b *testing.B) {
-	db, tmpDir := setupHonuDB(b)
-
-	// Cleanup when we're done with the test
-	defer os.RemoveAll(tmpDir)
-	defer db.Close()
+	db, _ := setupHonuDB(b)
 
 	// Create a key and value
 	for _, key := range []string{"aa", "bb", "cc", "dd", "ee", "ff", "gg", "hh", "ii", "jj"} {
@@ -219,11 +194,7 @@ func BenchmarkHonuIter(b *testing.B) {
 }
 
 func BenchmarkLevelDBIter(b *testing.B) {
-	db, tmpDir := setupLevelDB(b)
-
-	// Cleanup when we're done with the test
-	defer os.RemoveAll(tmpDir)
-	defer db.Close()
+	db, _ := setupLevelDB(b)
 
 	// Create a key and value
 	for _, key := range []string{"aa", "bb", "cc", "dd", "ee", "ff", "gg", "hh", "ii", "jj"} {
@@ -253,11 +224,7 @@ func BenchmarkLevelDBIter(b *testing.B) {
 }
 
 func BenchmarkHonuObject(b *testing.B) {
-	db, tmpDir := setupHonuDB(b)
-
-	// Cleanup when we're done with the test
-	defer os.RemoveAll(tmpDir)
-	defer db.Close()
+	db, _ := setupHonuDB(b)
 
 	// Create a key and value
 	key := []byte("foo")

--- a/engines/leveldb/leveldb.go
+++ b/engines/leveldb/leveldb.go
@@ -192,7 +192,7 @@ func (db *LevelDBEngine) Iter(prefix []byte, options *opts.Options) (i iterator.
 	if len(prefix) > 0 {
 		slice = util.BytesPrefix(prefix)
 	}
-	return NewLevelDBIterator(db.ldb.NewIterator(slice, options.LevelDBRead), options.Namespace), nil
+	return NewLevelDBIterator(db.ldb.NewIterator(slice, options.LevelDBRead), options), nil
 }
 
 var nssep = []byte("::")

--- a/engines/leveldb/leveldb_test.go
+++ b/engines/leveldb/leveldb_test.go
@@ -1,7 +1,6 @@
 package leveldb_test
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -54,7 +53,6 @@ func setupLevelDBEngine(t testing.TB) (_ *leveldb.LevelDBEngine, path string) {
 		// Teardown after finishing the test
 		engine.Close()
 		os.RemoveAll(tempDir)
-		fmt.Printf("cleaned up %s\n", tempDir)
 	})
 
 	return engine, tempDir

--- a/honu_test.go
+++ b/honu_test.go
@@ -40,22 +40,20 @@ var testNamespaces = []string{
 
 func setupHonuDB(t testing.TB) (db *honu.DB, tmpDir string) {
 	// Create a new leveldb database in a temporary directory
-	tmpDir, err := ioutil.TempDir("", "honuldb-*")
+	tmpDir, err := ioutil.TempDir("", "honudb-*")
 	require.NoError(t, err)
 
 	// Open a Honu leveldb database with default configuration
 	uri := fmt.Sprintf("leveldb:///%s", tmpDir)
 	db, err = honu.Open(uri, config.WithReplica(config.ReplicaConfig{PID: 8, Region: "us-southwest-16", Name: "testing"}))
-	require.NoError(t, err)
 	if err != nil && tmpDir != "" {
-		fmt.Println(tmpDir)
 		os.RemoveAll(tmpDir)
 	}
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		db.Close()
 		os.RemoveAll(tmpDir)
-		fmt.Printf("cleaned up %s\n", tmpDir)
 	})
 
 	return db, tmpDir

--- a/iterator/iterator.go
+++ b/iterator/iterator.go
@@ -1,9 +1,6 @@
 /*
 Package iterator provides an interface and implementations to traverse over the contents
 of an embedded database while maintaining and reading replicated object metadata.
-
-TODO: Implement IteratorSeeker interface from leveldb
-TODO: Implement sqliteIterator and genericize rows with key/values
 */
 package iterator
 
@@ -23,6 +20,7 @@ var (
 // a leveldb iterator or a sqlite rows context, fetching one row at a time in a Next
 // loop. The Iterator also provides access to the versioned metadata for low-level
 // interactions with the replicated data types.
+// TODO: Implement IteratorSeeker interface from leveldb
 type Iterator interface {
 	// Next moves the iterator to the next key/value pair or row.
 	// It returns false if the iterator has been exhausted.

--- a/options/options.go
+++ b/options/options.go
@@ -29,6 +29,7 @@ type Options struct {
 	PebbleWrite  *pebble.WriteOptions
 	Namespace    string
 	Force        bool
+	Tombstones   bool
 }
 
 // Defines the signature of functions accepted as parameters by Honu methods.
@@ -49,6 +50,14 @@ func WithNamespace(namespace string) Option {
 func WithForce() Option {
 	return func(cfg *Options) error {
 		cfg.Force = true
+		return nil
+	}
+}
+
+// WithTombstones causes the iterator to include tombstones as its iterating.
+func WithTombstones() Option {
+	return func(cfg *Options) error {
+		cfg.Tombstones = true
 		return nil
 	}
 }

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -14,6 +14,8 @@ func TestHonuOptions(t *testing.T) {
 	opts, err := options.New()
 	require.NoError(t, err, "could not create options")
 	require.Equal(t, options.NamespaceDefault, opts.Namespace)
+	require.False(t, opts.Force)
+	require.False(t, opts.Tombstones)
 
 	// Test setting multiple options
 	opts, err = options.New(options.WithLevelDBRead(&ldb.ReadOptions{Strict: ldb.StrictJournal}), options.WithNamespace("foo"))
@@ -26,6 +28,12 @@ func TestHonuOptions(t *testing.T) {
 	opts, err = options.New(options.WithNamespace(""))
 	require.NoError(t, err, "could not create options with empty string namespace")
 	require.Equal(t, options.NamespaceDefault, opts.Namespace)
+
+	// Test boolean options
+	opts, err = options.New(options.WithForce(), options.WithTombstones())
+	require.NoError(t, err, "boolean options returned an error")
+	require.True(t, opts.Force)
+	require.True(t, opts.Tombstones)
 }
 
 func TestLevelDBReadOptions(t *testing.T) {


### PR DESCRIPTION
Adds an option for iterating with tombstones but by default the `Iter` function skips tombstones to match the `Get` functionality. Also fixes the colons in namespace issue by removing the namespace prefix rather than splitting on the separator. Increases tests to ensure that `Iter` covers undead objects.

Note, this will require a change to Trtl replication, it must use the `WithTombstone` option when it is iterating in initiator phase 1 and remote phase 2; otherwise deletes will not be replicated.