### PR TITLE
Prevent Multi-Key Deadlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Honu
 
 [![Go Report Card](https://goreportcard.com/badge/go.rtnl.ai/honu)](https://goreportcard.com/report/go.rtnl.ai/honu)
-![GitHub Actions CI](https://github.com/rotationalio/honu/actions/workflows/tests.yaml/badge.svg?branch=main)
+[![GitHub Actions CI](https://github.com/rotationalio/honu/actions/workflows/tests.yaml/badge.svg?branch=main)](https://github.com/rotationalio/honu/actions/workflows/tests.yaml)
 
 The Honu Database is an eventually consistent replicated document database that intended for large systems that are distributed globally. Honu uses smart anti-entropy replication to quickly replicate collections across multiple nodes.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,8 +31,9 @@ type Config struct {
 }
 
 type StoreConfig struct {
-	ReadOnly bool   `default:"false" split_words:"false" desc:"open the the underlying data store in read-only mode"`
-	DataPath string `required:"true" split_words:"true" desc:"path to directory where data is stored (created if it doesn't exist)"`
+	ReadOnly    bool   `default:"false" split_words:"false" desc:"open the the underlying data store in read-only mode"`
+	DataPath    string `required:"true" split_words:"true" desc:"path to directory where data is stored (created if it doesn't exist)"`
+	Concurrency uint32 `default:"1024" desc:"number of concurrent read/write locks allowed for managing transactions"`
 }
 
 func New() (conf Config, err error) {

--- a/pkg/store/key/key.go
+++ b/pkg/store/key/key.go
@@ -26,11 +26,11 @@ var (
 
 // Keys are used to store objects in the underlying key/value store. It is a 45 byte key
 // that is composed of 16 byte object and collection IDs and a 4 byte uint32 and 8 byte
-// uint64 representing the lamport scalar version number. The last byte indicates the
+// uint64 representing the lamport scalar version number. The first byte indicates the
 // key version and marshaling compatibility. There are no separator characters
 // between the components of the key since all components are a fixed length.
 //
-// A key is structured as: collection::oid::vid::pid::keyVersion
+// A key is structured as keyVersion::collection::oid::vid::pid
 //
 // Note that the version is serialized differently than the lamport scalar in order to
 // maintain lexicographic sorting of the the data.

--- a/pkg/store/locks/locks.go
+++ b/pkg/store/locks/locks.go
@@ -3,34 +3,51 @@ The locks package implements a key-based lock mechanism that uses a crc32 hash t
 distribute keys across a fixed number of locks. This allows for concurrent access
 to different keys without contention, but fixes the number of locks (and therefore the
 amount of available concurrency) to ensure that memory usage is bounded.
+
+Locks help us implement simple transactions for the storage engine. At the start of a
+transaction before any other operation is performed, the transaction must acquire
+its read and write locks to all keys it wants to access in the transaction. The locks
+are acquired in a consistent order to prevent deadlocks.
+
+Reference: https://medium.com/@ksandeeptech07/handling-deadlocks-in-golang-gracefully-1f661c341a1d
 */
 package locks
 
 import (
 	"hash/crc32"
+	"sort"
 	"sync"
 )
 
 const DefaultCount = 1024
 
 type Keys interface {
-	Lock([]byte)
-	Unlock([]byte)
-	RLock([]byte)
-	RUnlock([]byte)
+	Lock(...[]byte)
+	Unlock(...[]byte)
+	RLock(...[]byte)
+	RUnlock(...[]byte)
 	Index([]byte) int
+	Indices(...[]byte) []int
 }
 
 // KeyLocks are used to prevent concurrent writes to the same key and to allow multiple
 // concurrent reads using a sync.RWMutex. The keys are distributed across a fixed number
-// to preven unbounded memory growth; so it is possible that two different keys will
-// share the same lock. Collection keys (keys without object ids or versions), object
-// prefix keys, and specific version keys are all locked with the same data structure.
+// of mutexes to preven unbounded memory growth; so it is possible that two different
+// keys will share the same lock. Collection keys (keys without object ids or versions),
+// object prefix keys, and specific version keys are all locked with the same data
+// structure.
+//
+// In a storage transaction, the transaction must acquire its read and write locks to
+// all keys it wants to access in the transaction. The locks are acquired and released
+// in a consistent order to prevent deadlocks. Multi-key locks must be acquired and
+// released at the same time without multiple calls to Lock or RLock.
 type KeyLock struct {
 	count uint32
 	locks []sync.RWMutex
 	table *crc32.Table
 }
+
+var _ Keys = (*KeyLock)(nil)
 
 // Create a new KeyLock with the given number of locks. The greater nlocks is, the
 // greater concurrency there is across the entire key space at the cost of more memory.
@@ -47,28 +64,126 @@ func New(nlocks uint32) *KeyLock {
 	}
 }
 
-// Acquire a write lock for the given key.
-func (k *KeyLock) Lock(key []byte) {
-	k.locks[crc32.Checksum(key, k.table)%k.count].Lock()
+// Acquire a write lock for the given keys. Note that the same exact keyset should be
+// unlocked all at once using the Unlock function and multiple calls to Lock before
+// unlocking should be avoided.
+//
+// The locks associated with the keys are identified by the index function, which is
+// deduplicated and sorted so that the highest index lock is always acquired first. As
+// long as the order of acquisition is consistent between different goroutines, you
+// won't get deadlocks, even for arbitrary subsets of the locks.
+func (k *KeyLock) Lock(keys ...[]byte) {
+	switch len(keys) {
+	case 0:
+		// TODO: should a no key lock allow locking the entire keyspace?
+		return
+	case 1:
+		k.locks[crc32.Checksum(keys[0], k.table)%k.count].Lock()
+	default:
+		indices := k.Indices(keys...)
+		for _, index := range indices {
+			k.locks[index].Lock()
+		}
+	}
 }
 
-// Unlock the write lock for the specified key.
-func (k *KeyLock) Unlock(key []byte) {
-	k.locks[crc32.Checksum(key, k.table)%k.count].Unlock()
+// Unlock the write lock for the specified keys. Note that the same exact keyset should
+// be unlocked all at once using the Unlock function before any calls to Lock or RLock.
+//
+// The locks associated with the keys are identified by the index function, which is
+// deduplicated and sorted so that the highest index lock is always acquired first. As
+// long as the order of acquisition is consistent between different goroutines, you
+// won't get deadlocks, even for arbitrary subsets of the locks.
+func (k *KeyLock) Unlock(keys ...[]byte) {
+	switch len(keys) {
+	case 0:
+		return
+	case 1:
+		k.locks[crc32.Checksum(keys[0], k.table)%k.count].Unlock()
+	default:
+		indices := k.Indices(keys...)
+		for _, index := range indices {
+			k.locks[index].Unlock()
+		}
+	}
 }
 
-// Acquire a read lock for the given key. Multiple read locks can be acquired
-// concurrently, but a write lock cannot be acquired while any read locks are held.
-func (k *KeyLock) RLock(key []byte) {
-	k.locks[crc32.Checksum(key, k.table)%k.count].RLock()
+// Acquire a read lock for the given keys. Multiple read locks can be acquired
+// concurrently, but a write lock cannot be acquired while any read locks are held and
+// no read locks can be acquired while a write lock is held. The same exact keyset
+// should be used with RUnlock to release the read locks and multiple calls to RLock or
+// Lock before unlocking should be avoided.
+//
+// The locks associated with the keys are identified by the index function, which is
+// deduplicated and sorted so that the highest index lock is always acquired first. As
+// long as the order of acquisition is consistent between different goroutines, you
+// won't get deadlocks, even for arbitrary subsets of the locks.
+func (k *KeyLock) RLock(keys ...[]byte) {
+	switch len(keys) {
+	case 0:
+		// TODO: should a no key lock allow read locking the entire keyspace?
+		return
+	case 1:
+		k.locks[crc32.Checksum(keys[0], k.table)%k.count].RLock()
+	default:
+		indices := k.Indices(keys...)
+		for _, index := range indices {
+			k.locks[index].RLock()
+		}
+	}
 }
 
-// Release a read lock for the specified key.
-func (k *KeyLock) RUnlock(key []byte) {
-	k.locks[crc32.Checksum(key, k.table)%k.count].RUnlock()
+// Release a read lock for the specified keys. Note that the same exact keyset should
+// be unlocked all at once using the RUnlock function before any calls to Lock or RLock.
+//
+// The locks associated with the keys are identified by the index function, which is
+// deduplicated and sorted so that the highest index lock is always acquired first. As
+// long as the order of acquisition is consistent between different goroutines, you
+// won't get deadlocks, even for arbitrary subsets of the locks.
+func (k *KeyLock) RUnlock(keys ...[]byte) {
+	switch len(keys) {
+	case 0:
+		return
+	case 1:
+		k.locks[crc32.Checksum(keys[0], k.table)%k.count].RUnlock()
+	default:
+		indices := k.Indices(keys...)
+		for _, index := range indices {
+			k.locks[index].RUnlock()
+		}
+	}
 }
 
 // Return the index of the lock for the given key (useful for debugging).
 func (k *KeyLock) Index(key []byte) int {
 	return int(crc32.Checksum(key, k.table) % k.count)
+}
+
+// Return a sorted, deduplicated slice of indices for the specified keys.
+func (k *KeyLock) Indices(keys ...[]byte) (out []int) {
+	// Find all indices associated with the keys
+	out = make([]int, len(keys))
+	for i, key := range keys {
+		out[i] = int(crc32.Checksum(key, k.table) % k.count)
+	}
+
+	// Return the indices if there are no duplicates
+	if len(out) < 2 {
+		return out
+	}
+
+	// Deduplicate the indices to ensure that within a keyspace, there is no locking
+	// deadlock (e.g. if we ask for locks for two keys with the same index in the same
+	// goroutine we would deadlock if we didn't deduplicate).
+	// Slice sort based deduplication is faster than map based deduplication.
+	sort.Slice(out, func(i, j int) bool { return out[i] > out[j] })
+	var e = 1
+	for i := 1; i < len(out); i++ {
+		if out[i] == out[i-1] {
+			continue
+		}
+		out[e] = out[i]
+		e++
+	}
+	return out[:e]
 }

--- a/pkg/store/locks/locks_test.go
+++ b/pkg/store/locks/locks_test.go
@@ -5,6 +5,7 @@ import (
 	random "math/rand/v2"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.rtnl.ai/honu/pkg/store/locks"
@@ -16,57 +17,214 @@ func TestLocking(t *testing.T) {
 	k2 := []byte{130, 255, 26, 113, 234, 106, 222, 190, 243, 205, 105, 236, 252, 191, 170, 22, 103, 99, 205, 208, 252, 137, 32, 197, 180, 40, 46, 90, 120, 224, 109, 215, 124, 190, 67, 208, 114, 208, 64, 13, 144, 88, 188, 112, 144}
 	k3 := []byte{43, 190, 204, 198, 110, 31, 120, 141, 165, 0, 172, 63, 39, 97, 37, 6, 189, 186, 23, 208, 124, 212, 163, 232, 153, 81, 105, 133, 147, 247, 192, 66, 253, 243, 163, 225, 35, 22, 230, 42, 55, 4, 83, 74, 240}
 
-	// Make sure the three keys have different indexes or this test will fail.
-	require.NotEqual(t, mu.Index(k1), mu.Index(k2))
-	require.NotEqual(t, mu.Index(k1), mu.Index(k3))
-	require.NotEqual(t, mu.Index(k2), mu.Index(k3))
+	t.Run("NoKey", func(t *testing.T) {
+		mu.Lock()
+		mu.Unlock()
 
-	mu.Lock(k1)
-	mu.Lock(k2)
-	mu.Lock(k3)
+		mu.RLock()
+		mu.RLock()
+		mu.RLock()
 
-	mu.Unlock(k2)
-	mu.RLock(k2)
-	mu.RLock(k2)
-	mu.RLock(k2)
+		mu.RUnlock()
+		mu.RUnlock()
+		mu.RUnlock()
+	})
 
-	mu.RUnlock(k2)
-	mu.RUnlock(k2)
-	mu.RUnlock(k2)
+	t.Run("Single", func(t *testing.T) {
+		// Make sure the three keys have different indexes or this test will fail.
+		require.NotEqual(t, mu.Index(k1), mu.Index(k2))
+		require.NotEqual(t, mu.Index(k1), mu.Index(k3))
+		require.NotEqual(t, mu.Index(k2), mu.Index(k3))
 
-	mu.Unlock(k1)
-	mu.Unlock(k3)
+		mu.Lock(k1)
+		mu.Lock(k2)
+		mu.Lock(k3)
+
+		mu.Unlock(k2)
+		mu.RLock(k2)
+		mu.RLock(k2)
+		mu.RLock(k2)
+
+		mu.RUnlock(k2)
+		mu.RUnlock(k2)
+		mu.RUnlock(k2)
+
+		mu.Unlock(k1)
+		mu.Unlock(k3)
+	})
+
+	t.Run("Multiple", func(t *testing.T) {
+		mu.Lock(k1, k2, k3)
+		mu.Unlock(k1, k2, k3)
+
+		mu.RLock(k1, k2, k3)
+		mu.RLock(k1, k2, k3)
+		mu.RLock(k1, k2, k3)
+
+		mu.RUnlock(k1, k2, k3)
+		mu.RUnlock(k1, k2, k3)
+		mu.RUnlock(k1, k2, k3)
+	})
 }
 
 func TestContention(t *testing.T) {
-	mu := locks.New(128)
-	wg := sync.WaitGroup{}
+	var (
+		writers    = 64
+		writes     = 256
+		writesleep = 32
+		readers    = 256
+		reads      = 512
+		readsleep  = 16
+		keyspace   = 512
+		locksize   = 128
+	)
 
-	wg.Add(1024)
-	for i := 0; i < 1024; i++ {
-		go func() {
-			defer wg.Done()
-			for j := 0; j < 512; j++ {
-				k := RandomKey()
-				mu.Lock(k)
-				mu.Unlock(k)
-			}
-		}()
-	}
+	t.Run("NoKey", func(t *testing.T) {
+		mu := locks.New(uint32(locksize))
+		wg := sync.WaitGroup{}
 
-	wg.Add(2048)
-	for i := 0; i < 2048; i++ {
-		go func() {
-			defer wg.Done()
-			for j := 0; j < 1024; j++ {
-				k := RandomKey()
-				mu.RLock(k)
-				mu.RUnlock(k)
-			}
-		}()
-	}
+		wg.Add(writers)
+		for range writers {
+			go func() {
+				defer wg.Done()
+				for range writes {
+					mu.Lock()
+					time.Sleep(time.Duration(random.IntN(writesleep)) * time.Microsecond)
+					mu.Unlock()
+				}
+			}()
+		}
 
-	wg.Wait()
+		wg.Add(readers)
+		for range readers {
+			go func() {
+				defer wg.Done()
+				for range reads {
+					mu.RLock()
+					time.Sleep(time.Duration(random.IntN(readsleep)) * time.Microsecond)
+					mu.RUnlock()
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("Single", func(t *testing.T) {
+		mu := locks.New(uint32(locksize))
+		wg := sync.WaitGroup{}
+
+		keys := make([][]byte, keyspace)
+		for i := range keyspace {
+			keys[i] = RandomKey()
+		}
+
+		wg.Add(writers)
+		for range writers {
+			go func() {
+				defer wg.Done()
+				k := keys[random.IntN(len(keys))]
+
+				for range writes {
+					mu.Lock(k)
+					time.Sleep(time.Duration(random.IntN(writesleep)) * time.Microsecond)
+					mu.Unlock(k)
+				}
+			}()
+		}
+
+		wg.Add(readers)
+		for range readers {
+			go func() {
+				defer wg.Done()
+				k := keys[random.IntN(len(keys))]
+
+				for range reads {
+					mu.RLock(k)
+					time.Sleep(time.Duration(random.IntN(readsleep)) * time.Microsecond)
+					mu.RUnlock(k)
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("Multiple", func(t *testing.T) {
+		mu := locks.New(uint32(locksize))
+		wg := sync.WaitGroup{}
+
+		keys := make([][]byte, keyspace)
+		for i := range keyspace {
+			keys[i] = RandomKey()
+		}
+
+		wg.Add(writers)
+		for range writers {
+			go func() {
+				defer wg.Done()
+
+				n := random.IntN(32)
+				ks := make([][]byte, n)
+				for j := range n {
+					ks[j] = keys[random.IntN(len(keys))]
+				}
+
+				for range writes {
+					mu.Lock(ks...)
+					time.Sleep(time.Duration(random.IntN(writesleep)) * time.Microsecond)
+					mu.Unlock(ks...)
+				}
+			}()
+		}
+
+		wg.Add(readers)
+		for range readers {
+			go func() {
+				defer wg.Done()
+
+				n := random.IntN(32)
+				ks := make([][]byte, n)
+				for j := range n {
+					ks[j] = keys[random.IntN(len(keys))]
+				}
+
+				for range reads {
+					mu.RLock(ks...)
+					time.Sleep(time.Duration(random.IntN(readsleep)) * time.Microsecond)
+					mu.RUnlock(ks...)
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+}
+
+func TestIndices(t *testing.T) {
+	t.Run("NoDuplicates", func(t *testing.T) {
+		mu := locks.New(128)
+		keys := [][]byte{
+			{1, 2, 3},
+			{4, 5, 6},
+			{7, 8, 9},
+		}
+
+		indices := mu.Indices(keys...)
+		require.Equal(t, []int{81, 42, 20}, indices)
+	})
+
+	t.Run("Duplicates", func(t *testing.T) {
+		mu := locks.New(8)
+		keys := make([][]byte, 128)
+		for i := 0; i < 128; i++ {
+			keys[i] = RandomKey()
+		}
+
+		indices := mu.Indices(keys...)
+		require.Equal(t, []int{7, 6, 5, 4, 3, 2, 1, 0}, indices)
+	})
+
 }
 
 func BenchmarkLocks(b *testing.B) {
@@ -90,7 +248,7 @@ func BenchmarkLocks(b *testing.B) {
 		wg.Wait()
 	}
 
-	b.Run("Mutex", func(b *testing.B) {
+	b.Run("Sync", func(b *testing.B) {
 		var mu sync.Mutex
 		for i := 0; i < b.N; i++ {
 			runContention(func(k []byte) {
@@ -101,8 +259,19 @@ func BenchmarkLocks(b *testing.B) {
 		}
 	})
 
-	b.Run("KeyLock", func(b *testing.B) {
+	b.Run("KeyLock128", func(b *testing.B) {
 		mu := locks.New(128)
+		for i := 0; i < b.N; i++ {
+			runContention(func(k []byte) {
+				mu.Lock(k)
+				_ = len(k)
+				mu.Unlock(k)
+			})
+		}
+	})
+
+	b.Run("KeyLock1024", func(b *testing.B) {
+		mu := locks.New(1024)
 		for i := 0; i < b.N; i++ {
 			runContention(func(k []byte) {
 				mu.Lock(k)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -31,7 +31,7 @@ func Open(conf config.Config) (s *Store, err error) {
 	s = &Store{
 		Clock: lamport.New(conf.PID),
 		pid:   lamport.PID(conf.PID),
-		mu:    locks.New(locks.DefaultCount),
+		mu:    locks.New(conf.Store.Concurrency),
 	}
 
 	if s.db, err = leveldb.Open(conf.Store); err != nil {


### PR DESCRIPTION
### Scope of changes

This PR prevents multi-key deadlock when taking locks for a transaction by ensuring that the following happens:

1. All indexes are deduplicated
2. Indexes are sorted for lock acquisition

According to [Handling Deadlocks in Golang Gracefully](https://medium.com/@ksandeeptech07/handling-deadlocks-in-golang-gracefully-1f661c341a1d), deadlocks can be prevented when:

> Ensure that all goroutines acquire locks in the same order. This prevents circular waiting conditions that lead to deadlocks.

The idea is that if the locks are acquired and released in the same order, then you can't get in the situation where one process is waiting for one set of locks and another process is waiting for a subset of locks. 

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [x] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

This PR will be merged without review.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests
- [x] I have added unit and/or integration tests that cover my changes
- [x] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)

<!--
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

-->
